### PR TITLE
HTML-escaping of xss payload in NodeJS Applcation Path

### DIFF
--- a/src/web/nodejs.jsp
+++ b/src/web/nodejs.jsp
@@ -3,6 +3,7 @@
 <%@ page import="org.ifsoft.nodejs.openfire.*" %>
 <%@ page import="org.jivesoftware.openfire.*" %>
 <%@ page import="org.jivesoftware.util.*" %>
+<%@ page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%
@@ -50,7 +51,7 @@
             <fmt:message key="config.page.configuration.path"/>
         </td>
         <td><input type="text" size="50" maxlength="100" name="path"
-               value="<%= JiveGlobals.getProperty("org.ifsoft.nodejs.openfire.path", plugin.getPath()) %>">
+               value="<%= StringEscapeUtils.escapeHtml4(JiveGlobals.getProperty("org.ifsoft.nodejs.openfire.path", plugin.getPath())) %>">
         </td>
         </tr>            
             </tbody>


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-openfire-nodejs-plugin/

### ⚙️ Description *

In the field of Nodejs Application path in the page of the plugin, the (dangerous)  characters of the vulnerable field that can cause an XSS are transformed in a way the are not dangerous any more


### 💻 Technical Description *

The XSS payload was inserted in the html template without escaping the dangerous characters. The fix is using the method that HTML-escapes dangerous characters in the apache.commons.text (already present in the pom of the project); the field content is now rendered in a safe way without causing xss

### 🐛 Proof of Concept (PoC) *

The video shows how the payload triggers the XSS after saving the change. The version of the plugin is the one on the marketplace


https://user-images.githubusercontent.com/62958189/105398049-225b8a00-5c22-11eb-84df-0c56de1e1148.mp4



### 🔥 Proof of Fix (PoF) *

The video shows that the payload doesn't trigger XSS anymore thantk to escaping some characters. The version of the plugin is 0.1.2-SNAPSHOT.


https://user-images.githubusercontent.com/62958189/105398108-3c956800-5c22-11eb-8049-db7a4891c666.mp4



### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly as before the fix and the XSS is not triggered anymore. All the changes made are on the way the page is rendered and no backend business logic has been changed, preserving correct functionality-
